### PR TITLE
fix: tslint.json actualizado. (Ver mensaje del commit)

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -122,10 +122,10 @@
         "message": "please don't"
       }
     ],
-    "use-input-property-decorator": true,
-    "use-output-property-decorator": true,
+    "no-inputs-metadata-property": true,
+    "no-outputs-metadata-property": true,
     "no-output-rename": true,
-    "use-life-cycle-interface": true,
+    "use-lifecycle-interface": true,
     "use-pipe-transform-interface": true,
     "component-class-suffix": true,
     "directive-class-suffix": true


### PR DESCRIPTION
Al ejecutar 'ng lint' salían los siguientes avisos...:

```
Could not find implementations for the following rules specified in the configuration:
    use-input-property-decorator
    use-output-property-decorator
    use-life-cycle-interface
Try upgrading TSLint and/or ensuring that you have all necessary custom rules installed.
If TSLint was recently upgraded, you may have old rules configured which need to be cleaned up.
```

... que dejaron de aparecer tras seguir los reemplazos indicados en
https://github.com/mgechev/codelyzer/issues/791#issuecomment-474031004