### PR TITLE
fix: Extensión en carga masiva

### DIFF
--- a/src/app/pages/acta-recibido/capturar-elementos/capturar-elementos.component.ts
+++ b/src/app/pages/acta-recibido/capturar-elementos/capturar-elementos.component.ts
@@ -166,7 +166,7 @@ export class CapturarElementosComponent implements OnInit {
     if (event.target.files.length > 0) {
       nombre = event.target.files[0].name;
       this.nombreArchivo = event.target.files[0].name;
-      const [_, extension] = nombre.split('.');
+      const extension = nombre.split('.').pop();
       const file = event.target.files[0];
       if (extension !== 'xlsx') {
         this.Validador = false;


### PR DESCRIPTION
Si el nombre de archivo en carga masiva incluye uno o más puntos adicionales, puede reconocer la extensión mal:

![image](https://user-images.githubusercontent.com/6588872/101374044-ad9fdc80-387b-11eb-9236-d9a0b8027c0d.png)

Con este fix se toma únicamente el último grupo después del split.
