### PR TITLE
feat: #380 Un soporte por acta (se desactiva agregar/quitar)

### DIFF
--- a/src/app/pages/acta-recibido/edicion-acta-recibido/edicion-acta-recibido.component.html
+++ b/src/app/pages/acta-recibido/edicion-acta-recibido/edicion-acta-recibido.component.html
@@ -88,7 +88,7 @@
                     [formGroupName]="i">
                     <ng-template mat-tab-label>
                       {{'GLOBAL.Acta_Recibido.EdicionActa.SoporteSubTitle' | translate}} &nbsp; {{i + 1}} &nbsp; &nbsp;
-                      &nbsp; &nbsp;<i class="fas fa-window-close" (click)="removeTab(i); usarLocalStorage()" *ngIf="getPermisoEditar(permisos.Acta)"></i>
+                      &nbsp; &nbsp;<i class="fas fa-window-close" (click)="removeTab(i); usarLocalStorage()" *ngIf="false && getPermisoEditar(permisos.Acta)"></i>
                     </ng-template>
                     <div>
 
@@ -203,7 +203,7 @@
 
                     </div>
                   </mat-tab>
-                  <mat-tab [disabled]="true" *ngIf="getPermisoEditar(permisos.Acta)">
+                  <mat-tab [disabled]="true" *ngIf="false && getPermisoEditar(permisos.Acta)">
                     <ng-template mat-tab-label>
                       <i class="fas fa-plus-square fa-2x" (click)="addTab(); usarLocalStorage()"></i>
                     </ng-template>

--- a/src/app/pages/acta-recibido/registro-acta-recibido/registro-acta-recibido.component.html
+++ b/src/app/pages/acta-recibido/registro-acta-recibido/registro-acta-recibido.component.html
@@ -13,6 +13,8 @@
       <nb-card-header>{{'GLOBAL.Acta_Recibido.RegistroActa.Title' | translate}}</nb-card-header>
       <nb-card-body [nbSpinner]="Registrando">
         <mat-vertical-stepper [linear]="true" #stepper>
+
+          <!-- Datos iniciales -->
           <mat-step label="{{'GLOBAL.Acta_Recibido.RegistroActa.DatosTitle' | translate}}" formGroupName="Formulario1">
             <nb-card [nbSpinner]="!Sedes || !Dependencias">
               <nb-card-body class="bla">
@@ -56,16 +58,20 @@
               </nb-card-footer>
             </nb-card>
           </mat-step>
+
+          <!-- Soportes -->
           <mat-step label="{{'GLOBAL.Acta_Recibido.RegistroActa.SoporteTitle' | translate}}"
             formArrayName="Formulario2">
             <nb-card>
               <nb-card-body>
                 <mat-tab-group [selectedIndex]="selected.value" (selectedIndexChange)="selected.setValue($event)">
+
+                  <!-- cada soporte -->
                   <mat-tab *ngFor="let soporte of firstForm.get('Formulario2').controls; let i = index"
                     [formGroupName]="i">
                     <ng-template mat-tab-label>
                       {{'GLOBAL.Acta_Recibido.RegistroActa.SoporteSubTitle' | translate}} &nbsp; {{i + 1}} &nbsp; &nbsp;
-                      &nbsp; &nbsp;<i class="fas fa-window-close" (click)="removeTab(i); usarLocalStorage()"></i>
+                      &nbsp; &nbsp;<i class="fas fa-window-close" (click)="removeTab(i); usarLocalStorage()" *ngIf="false"></i>
                     </ng-template>
                     <div>
                       <nb-card>
@@ -161,7 +167,7 @@
                       </nb-card>
                     </div>
                   </mat-tab>
-                  <mat-tab [disabled]="true">
+                  <mat-tab [disabled]="true" *ngIf="false">
                     <ng-template mat-tab-label>
                       <i class="fas fa-plus-square fa-2x" (click)="addTab(); usarLocalStorage()"></i>
                     </ng-template>


### PR DESCRIPTION
Closes #380 

Se desactivan los controles para agregar/quitar soportes, con lo que se permite registrar únicamente un soporte por acta, y permitiendo así visualizar actas que tengan mas/menos de un soporte.

No se eliminan completamente, en caso que a futuro se requiera retomar esta característica