### PR TITLE
fix:guardar clase null

### DIFF
--- a/src/app/pages/acta-recibido/capturar-elementos/capturar-elementos.component.html
+++ b/src/app/pages/acta-recibido/capturar-elementos/capturar-elementos.component.html
@@ -40,10 +40,10 @@
   <nb-card-body>
 
     <div class="row">
-      <button nbButton (click)="borraSeleccionados()" style="margin-left: 10px;height: 45px;">Borrar
+      <button nbButton [disabled]="!checkParcial && !checkTodos"  (click)="borraSeleccionados()" style="margin-left: 10px;height: 45px;">Borrar
         Seleccionados</button>
       <div class="col">
-        <ng2-completer type="text" inputClass="cell form-control" style="height: 8px;" placeholder="Asignar clase"
+        <ng2-completer *ngIf="!Proveedor" type="text" inputClass="cell form-control" style="height: 8px;" placeholder="Asignar clase"
           [datasource]="dataService" [minSearchLength]="4" (selected)="onClase($event)"
           [disableInput]="!checkParcial && !checkTodos" [clearSelected]="true" [clearUnselected]="false">
         </ng2-completer>

--- a/src/app/pages/acta-recibido/capturar-elementos/capturar-elementos.component.ts
+++ b/src/app/pages/acta-recibido/capturar-elementos/capturar-elementos.component.ts
@@ -70,6 +70,7 @@ export class CapturarElementosComponent implements OnInit {
   displayedColumns: any[];
   checkTodos: boolean = false;
   checkParcial: boolean = false;
+  Proveedor: boolean;
 
   constructor(private fb: FormBuilder,
     private translate: TranslateService,
@@ -144,6 +145,7 @@ export class CapturarElementosComponent implements OnInit {
 
   ReglasColumnas() {
     if (this.userService.tieneAlgunRol([Rol.Proveedor])) {
+      this.Proveedor = true;
       this.displayedColumns = [
         'AccionesMacro',
         'Nombre',
@@ -382,9 +384,12 @@ export class CapturarElementosComponent implements OnInit {
   getClasesElementos() {
     if (this.Clases && this.Clases.length) {
       this.dataSource.data.map((elemento) => {
-        elemento.TipoBienNombre = this.Tipos_Bien.find((x) => x.Id === elemento.TipoBienId).Nombre;
-        elemento.CodigoSubgrupo = this.Clases.find((x) => x.SubgrupoId.Id === elemento.SubgrupoCatalogoId).SubgrupoId.Codigo;
-        elemento.NombreClase = this.Clases.find((x) => x.SubgrupoId.Id === elemento.SubgrupoCatalogoId).SubgrupoId.Nombre;
+        elemento.TipoBienNombre = elemento.TipoBienId !== 0 ?
+          this.Tipos_Bien.find((x) => x.Id === elemento.TipoBienId).Nombre : '';
+        elemento.CodigoSubgrupo = elemento.TipoBienId !== 0 ?
+        this.Clases.find((x) => x.SubgrupoId.Id === elemento.SubgrupoCatalogoId).SubgrupoId.Codigo : '';
+        elemento.NombreClase = elemento.TipoBienId !== 0 ?
+        this.Clases.find((x) => x.SubgrupoId.Id === elemento.SubgrupoCatalogoId).SubgrupoId.Nombre : '';
       });
     }
   }

--- a/src/app/pages/acta-recibido/edicion-acta-recibido/edicion-acta-recibido.component.html
+++ b/src/app/pages/acta-recibido/edicion-acta-recibido/edicion-acta-recibido.component.html
@@ -266,7 +266,7 @@
                   <button nbButton
                     matStepperPrevious>{{'GLOBAL.Acta_Recibido.EdicionActa.AnteriorButton' | translate}}</button>
                   <button nbButton matStepperNext (click)="usarLocalStorage()"
-                    [disabled]="!firstForm.get('Formulario1').valid || !firstForm.get('Formulario2').valid"
+                    [disabled]="!firstForm.get('Formulario1').valid || (!firstForm.get('Formulario2').valid && !ActaEspecial)"
                     class="float-right">{{'GLOBAL.Acta_Recibido.EdicionActa.SiguienteButton' | translate}}</button>
                 </div>
               </nb-card-footer>

--- a/src/app/pages/acta-recibido/edicion-acta-recibido/edicion-acta-recibido.component.ts
+++ b/src/app/pages/acta-recibido/edicion-acta-recibido/edicion-acta-recibido.component.ts
@@ -360,7 +360,8 @@ export class EdicionActaRecibidoComponent implements OnInit {
 
             const Elemento___ = {
               Id: _Elemento.Id,
-              TipoBienId: this.Tipos_Bien.find(tipo => tipo.Id.toString() === _Elemento.TipoBienId.Id.toString()).Id,
+              TipoBienId: _Elemento.TipoBienId !== null ?
+                this.Tipos_Bien.find(tipo => tipo.Id.toString() === _Elemento.TipoBienId.Id.toString()).Id : 0,
               SubgrupoCatalogoId: _Elemento.SubgrupoCatalogoId,
               Nombre: _Elemento.Nombre,
               Cantidad: _Elemento.Cantidad,
@@ -392,7 +393,8 @@ export class EdicionActaRecibidoComponent implements OnInit {
             Validators.required,
           ],
           Revisor: [
-            this.Proveedores.find(proveedor => proveedor.Id.toString() === transaccion_.ActaRecibido.PersonaAsignada.toString()).compuesto,
+            this.Proveedores.find(proveedor =>
+              proveedor.Id.toString() === transaccion_.ActaRecibido.PersonaAsignada.toString() || { proveedor : 0 }).compuesto,
             Validators.required,
           ],
         }),

--- a/src/app/pages/acta-recibido/ver-detalle/ver-detalle.component.ts
+++ b/src/app/pages/acta-recibido/ver-detalle/ver-detalle.component.ts
@@ -184,7 +184,7 @@ export class VerDetalleComponent implements OnInit {
           const Elemento___ = this.fb.group({
             Id: [_Elemento.Id],
             TipoBienId: [
-              this.Tipos_Bien.find(bien => bien.Id.toString() === _Elemento.TipoBienId.Id.toString()).Nombre,
+              _Elemento.TipoBienId !== null ? this.Tipos_Bien.find(bien => bien.Id.toString() === _Elemento.TipoBienId.Id.toString()).Nombre : '',
             ],
             SubgrupoCatalogoId: [_Elemento.SubgrupoCatalogoId],
             Nombre: [_Elemento.Nombre],


### PR DESCRIPTION
Se ajusta componente de edición y registro de acta especial para poder crear y luego visualizar elementos que no tengan una clase asignada.

El botón de eliminar varios elementos se inhabilita cuando corresponde.
El completer para asignar múltiples clases se inhabilita el proveedor.
Se hace el mismo ajuste en ver-detalle.