### PR TITLE
Fix/cuentas catalogo

### DIFF
--- a/src/app/@core/data/models/base.ts
+++ b/src/app/@core/data/models/base.ts
@@ -1,5 +1,8 @@
-export class Base {
+export class BaseId {
     Id: number;
+}
+
+export class Base extends BaseId {
     Activo: boolean;
     FechaCreacion: Date;
     FechaModificacion: Date;

--- a/src/app/@core/data/models/catalogo/cuentas_grupo.ts
+++ b/src/app/@core/data/models/catalogo/cuentas_grupo.ts
@@ -10,7 +10,7 @@ export class CuentaGrupo {
     FechaCreacion: Date;
     FechaModificacion: Date;
     Activo: boolean;
-    SubgrupoId: SubgrupoID;
+    SubgrupoId: Partial<SubgrupoID>;
 }
 export class CuentasFormulario {
     CuentaCreditoId: Cuenta;

--- a/src/app/pages/catalogo-bienes/registro-cuentas-catalogo/registro-cuentas-catalogo.component.ts
+++ b/src/app/pages/catalogo-bienes/registro-cuentas-catalogo/registro-cuentas-catalogo.component.ts
@@ -4,6 +4,7 @@ import { CatalogoElementosHelper } from '../../../helpers/catalogo-elementos/cat
 import { Grupo, Subgrupo } from '../../../@core/data/models/catalogo/jerarquia';
 import { Nivel_t } from '../../../@core/data/models/catalogo/tipo_nivel';
 import { Catalogo } from '../../../@core/data/models/catalogo/catalogo';
+import { BaseId } from '../../../@core/data/models/base';
 import Swal from 'sweetalert2';
 import { Store } from '@ngrx/store';
 import { IAppState } from '../../../@core/store/app.state';
@@ -185,8 +186,13 @@ export class RegistroCuentasCatalogoComponent implements OnInit {
     (Swal as any).fire(opt)
       .then((willDelete) => {
         if (willDelete.value) {
-          const mov: any = {};
-          mov['Cuentas'] = subgrupo;
+          const mov = {Cuentas: subgrupo.map( (cuenta: CuentaGrupo) => {
+            const subgrupo_id: BaseId = {Id: cuenta.SubgrupoId.Id};
+            cuenta.SubgrupoId = subgrupo_id;
+            cuenta.FechaCreacion = undefined;
+            cuenta.FechaModificacion = undefined;
+            return cuenta;
+          })};
           // console.log(mov)
           // console.log(this.uid_1.Id);
           this.catalogoElementosService.putTransaccionCuentasSubgrupo(mov, this.uid_1.Id)

--- a/src/app/pages/catalogo-bienes/registro-cuentas-catalogo/registro-cuentas-catalogo.component.ts
+++ b/src/app/pages/catalogo-bienes/registro-cuentas-catalogo/registro-cuentas-catalogo.component.ts
@@ -169,21 +169,11 @@ export class RegistroCuentasCatalogoComponent implements OnInit {
       }
     } else this.uid_1 = undefined;
   }
-  onSubmit() {
-    let mov_existente: boolean;
-    this.Movimientos.forEach((element3: CuentaGrupo) => {
-      // console.log(element3)
-      if (element3.Id !== null && element3.Id !== undefined) {
-        mov_existente = true;
-      }
-    });
 
-    if (mov_existente !== true) {
-      this.createMovimientos(this.Movimientos);
-    } else {
+  onSubmit() {
       this.updateMovimientos(this.Movimientos);
-    }
   }
+
   updateMovimientos(subgrupo: any): void {
 
     const opt: any = {
@@ -217,32 +207,6 @@ export class RegistroCuentasCatalogoComponent implements OnInit {
       });
   }
 
-  createMovimientos(subgrupo: any): void {
-    const opt: any = {
-      title: this.translate.instant('GLOBAL.Crear'),
-      text: this.translate.instant('GLOBAL.Crear_Movimientos_placeholder'),
-      type: 'warning',
-      showCancelButton: true,
-    };
-    (Swal as any).fire(opt)
-      .then((willDelete) => {
-        if (willDelete.value) {
-          const mov: any = {};
-          mov['Cuentas'] = subgrupo;
-          // console.log(mov['Cuentas'])
-          this.catalogoElementosService.postTransaccionCuentasSubgrupo(mov)
-            .subscribe(res => {
-              // console.log(res);
-              this.recargarCatalogo();
-              this.Movimientos = [];
-              this.showToast('info', this.translate.instant('GLOBAL.Creado'), this.translate.instant('GLOBAL.Creado_Movimientos_placeholder'));
-              setTimeout(() => {
-                this.QuitarVista();
-              }, 2000);
-            });
-        }
-      });
-  }
   private showToast(type: string, title: string, body: string) {
     this.config = new ToasterConfig({
       // 'toast-top-full-width', 'toast-bottom-full-width', 'toast-top-left', 'toast-top-center'


### PR DESCRIPTION
Avance parcial de #469

Realmente es un refactor menor: En udistrital/catalogo_elementos_crud#59 se observó que el controlador PUT de tr_cuentas_subgrupo no solamente "actualiza" registros en la tabla "cuentas_subgrupo" sino que los crea si no existen, por lo que no es necesaria la transacción POST de tr_cuentas_subgrupo...

Por lo anterior, se quitó esta transacción (del lado del cliente) para simplificar el desarrollo y la UX