### PR TITLE
Fix/bugs actas

### DIFF
--- a/src/app/pages/acta-recibido/acta-especial/acta-especial.component.html
+++ b/src/app/pages/acta-recibido/acta-especial/acta-especial.component.html
@@ -1,5 +1,5 @@
 <nb-card>
-  <nb-card-header>{{'GLOBAL.Acta_Recibido.RegistroActa.Title' | translate}}</nb-card-header>
+  <nb-card-header><h2>{{'GLOBAL.Acta_Recibido.RegistroActa.Title' | translate}}</h2></nb-card-header>
   <nb-card-body [nbSpinner]="Registrando || !firstForm">
     <form [formGroup]="firstForm" #fform="ngForm" class="step-container" *ngIf="firstForm">
         <mat-vertical-stepper [linear]="true" #stepper>

--- a/src/app/pages/acta-recibido/acta-especial/acta-especial.component.html
+++ b/src/app/pages/acta-recibido/acta-especial/acta-especial.component.html
@@ -1,18 +1,9 @@
-<div *ngIf="!firstForm" [nbSpinner]="!firstForm">
-  <nb-card>
-    <nb-card-header>
-    </nb-card-header>
-    <nb-card-body>
-    </nb-card-body>
-  </nb-card>
-</div>
-
-<div class="col-lg-12" *ngIf="firstForm">
-  <form [formGroup]="firstForm" #fform="ngForm" class="step-container">
-    <nb-card>
-      <nb-card-header>{{'GLOBAL.Acta_Recibido.RegistroActa.Title' | translate}}</nb-card-header>
-      <nb-card-body [nbSpinner]="Registrando">
+<nb-card>
+  <nb-card-header>{{'GLOBAL.Acta_Recibido.RegistroActa.Title' | translate}}</nb-card-header>
+  <nb-card-body [nbSpinner]="Registrando || !firstForm">
+    <form [formGroup]="firstForm" #fform="ngForm" class="step-container" *ngIf="firstForm">
         <mat-vertical-stepper [linear]="true" #stepper>
+
           <mat-step label="{{'GLOBAL.Acta_Recibido.RegistroActa.DatosTitle' | translate}}" formGroupName="Formulario1">
             <nb-card [nbSpinner]="!Sedes || !Dependencias">
               <nb-card-body class="bla">
@@ -57,6 +48,7 @@
               </nb-card-footer>
             </nb-card>
           </mat-step>
+
           <mat-step label="{{'GLOBAL.Acta_Recibido.RegistroActa.SoporteTitle' | translate}}"
             formArrayName="Formulario2">
             <nb-card>
@@ -138,42 +130,22 @@
             <nb-card *ngIf="Totales">
               <nb-card-header>{{'GLOBAL.Acta_Recibido.RegistroActa.Consolidado' | translate}}</nb-card-header>
               <nb-card-body>
-                <table>
+                <table class="consolidado">
                   <tr>
-                    <td class="cell-3"></td>
-                    <td class="cell-3"></td>
-                    <td class="cell-3">{{'GLOBAL.Acta_Recibido.RegistroActa.Subtotal' | translate}}</td>
-                    <td class="cell-3"></td>
+                    <th class="cell-3">{{'GLOBAL.Acta_Recibido.RegistroActa.Subtotal' | translate}}</th>
                     <td class="cell-3">{{getGranSubtotal() | currency}}</td>
-                    <td class="cell-3"></td>
-                    <td class="cell-3"></td>
                   </tr>
                   <tr>
-                    <td class="cell-3"></td>
-                    <td class="cell-3"></td>
-                    <td class="cell-3">{{'GLOBAL.Acta_Recibido.RegistroActa.Descuento' | translate}}</td>
-                    <td class="cell-3"></td>
+                    <th class="cell-3">{{'GLOBAL.Acta_Recibido.RegistroActa.Descuento' | translate}}</th>
                     <td class="cell-3">{{getGranDescuentos() | currency}}</td>
-                    <td class="cell-3"></td>
-                    <td class="cell-3"></td>
                   </tr>
                   <tr>
-                    <td class="cell-3"></td>
-                    <td class="cell-3"></td>
-                    <td class="cell-3">{{'GLOBAL.Acta_Recibido.RegistroActa.ValorIva' | translate}}</td>
-                    <td class="cell-3"></td>
+                    <th class="cell-3">{{'GLOBAL.Acta_Recibido.RegistroActa.ValorIva' | translate}}</th>
                     <td class="cell-3">{{getGranValorIva() | currency}}</td>
-                    <td class="cell-3"></td>
-                    <td class="cell-3"></td>
                   </tr>
                   <tr>
-                    <td class="cell-3"></td>
-                    <td class="cell-3"></td>
-                    <td class="cell-3">{{'GLOBAL.Acta_Recibido.RegistroActa.Total' | translate}}</td>
-                    <td class="cell-3"></td>
+                    <th class="cell-3">{{'GLOBAL.Acta_Recibido.RegistroActa.Total' | translate}}</th>
                     <td class="cell-3">{{getGranTotal() | currency}}</td>
-                    <td class="cell-3"></td>
-                    <td class="cell-3"></td>
                   </tr>
                 </table>
               </nb-card-body>
@@ -203,11 +175,9 @@
                 </div>
               </nb-card-footer>
             </nb-card>
-
           </mat-step>
 
         </mat-vertical-stepper>
-      </nb-card-body>
-    </nb-card>
-  </form>
-</div>
+    </form>
+  </nb-card-body>
+</nb-card>

--- a/src/app/pages/acta-recibido/acta-especial/acta-especial.component.scss
+++ b/src/app/pages/acta-recibido/acta-especial/acta-especial.component.scss
@@ -62,3 +62,8 @@
   overflow-y: scroll;
   overflow-x: hidden;
 }
+
+table.consolidado {
+  width: auto;
+  margin: auto;
+}

--- a/src/app/pages/acta-recibido/capturar-elementos/capturar-elementos.component.ts
+++ b/src/app/pages/acta-recibido/capturar-elementos/capturar-elementos.component.ts
@@ -400,6 +400,11 @@ export class CapturarElementosComponent implements OnInit {
   }
 
   onSubmit() {
+    const cargar = () => {
+      this.checkAnterior = undefined;
+      this.basePaginas = 0;
+      this.readThis();
+    };
     if (this.dataSource.data.length) {
       (Swal as any).fire({
         title: this.translate.instant('GLOBAL.Advertencia'),
@@ -408,11 +413,11 @@ export class CapturarElementosComponent implements OnInit {
         showCancelButton: true,
       }).then( res => {
         if (res.value) {
-          this.checkAnterior = undefined;
-          this.basePaginas = 0;
-          this.readThis();
+          cargar();
         }
       });
+    } else {
+      cargar();
     }
   }
 

--- a/src/app/pages/acta-recibido/consulta-acta-recibido/consulta-acta-recibido.component.html
+++ b/src/app/pages/acta-recibido/consulta-acta-recibido/consulta-acta-recibido.component.html
@@ -1,5 +1,5 @@
   <nb-card *ngIf="!(editarActa||verActa||validarActa)">
-    <nb-card-header>{{'GLOBAL.Acta_Recibido.varias' | translate}}</nb-card-header>
+    <nb-card-header><h2>{{'GLOBAL.Acta_Recibido.varias' | translate}}</h2></nb-card-header>
     <nb-card-body [nbSpinner]="!mostrar">
       <ng2-smart-table [settings]="settings" [source]="source" (delete)="onDelete($event)"
         (userRowSelect)="seleccionarActa($event)" (edit)="onEdit($event)" (create)="onCreate($event)">

--- a/src/app/pages/acta-recibido/consulta-acta-recibido/consulta-acta-recibido.component.html
+++ b/src/app/pages/acta-recibido/consulta-acta-recibido/consulta-acta-recibido.component.html
@@ -1,4 +1,3 @@
-<div class="col-lg-12">
   <nb-card *ngIf="!(editarActa||verActa||validarActa)">
     <nb-card-header>{{'GLOBAL.Acta_Recibido.varias' | translate}}</nb-card-header>
     <nb-card-body [nbSpinner]="!mostrar">
@@ -25,4 +24,3 @@
       {{'GLOBAL.Acta_Recibido.VerificacionActa.Volver' | translate}}
     </button>
   </div>
-</div>

--- a/src/app/pages/acta-recibido/edicion-acta-recibido/edicion-acta-recibido.component.html
+++ b/src/app/pages/acta-recibido/edicion-acta-recibido/edicion-acta-recibido.component.html
@@ -217,19 +217,19 @@
               <nb-card-body>
                 <table class="consolidado">
                   <tr>
-                    <td class="cell-3">{{'GLOBAL.Acta_Recibido.EdicionActa.Subtotal' | translate}}</td>
+                    <th class="cell-3">{{'GLOBAL.Acta_Recibido.EdicionActa.Subtotal' | translate}}</th>
                     <td class="cell-3">{{getGranSubtotal() | currency}}</td>
                   </tr>
                   <tr>
-                    <td class="cell-3">{{'GLOBAL.Acta_Recibido.EdicionActa.Descuento' | translate}}</td>
+                    <th class="cell-3">{{'GLOBAL.Acta_Recibido.EdicionActa.Descuento' | translate}}</th>
                     <td class="cell-3">{{getGranDescuentos() | currency}}</td>
                   </tr>
                   <tr>
-                    <td class="cell-3">{{'GLOBAL.Acta_Recibido.EdicionActa.ValorIva' | translate}}</td>
+                    <th class="cell-3">{{'GLOBAL.Acta_Recibido.EdicionActa.ValorIva' | translate}}</th>
                     <td class="cell-3">{{getGranValorIva() | currency}}</td>
                   </tr>
                   <tr>
-                    <td class="cell-3">{{'GLOBAL.Acta_Recibido.EdicionActa.Total' | translate}}</td>
+                    <th class="cell-3">{{'GLOBAL.Acta_Recibido.EdicionActa.Total' | translate}}</th>
                     <td class="cell-3">{{getGranTotal() | currency}}</td>
                   </tr>
                 </table>

--- a/src/app/pages/acta-recibido/edicion-acta-recibido/edicion-acta-recibido.component.html
+++ b/src/app/pages/acta-recibido/edicion-acta-recibido/edicion-acta-recibido.component.html
@@ -1,5 +1,5 @@
 <nb-card>
-  <nb-card-header><h2>{{'GLOBAL.Acta_Recibido.EdicionActa.Title' | translate}}</h2></nb-card-header>
+  <nb-card-header><h2>{{'GLOBAL.Acta_Recibido.EdicionActa.TitleId' | translate: {ID: _Acta_Id} }}</h2></nb-card-header>
   <nb-card-body [nbSpinner]="!firstForm || guardando">
     <form *ngIf="firstForm" [formGroup]="firstForm" #fform="ngForm" class="step-container">
       <mat-vertical-stepper [linear]="true" #stepper>

--- a/src/app/pages/acta-recibido/edicion-acta-recibido/edicion-acta-recibido.component.ts
+++ b/src/app/pages/acta-recibido/edicion-acta-recibido/edicion-acta-recibido.component.ts
@@ -466,9 +466,11 @@ export class EdicionActaRecibidoComponent implements OnInit {
             transaccion_.ActaRecibido.UbicacionId,
             Validators.required,
           ],
-          Revisor: [
-            this.Proveedores.find(proveedor =>
-              proveedor.Id.toString() === transaccion_.ActaRecibido.PersonaAsignada.toString()).compuesto,
+          Revisor: [ (() => {
+            const criterio = proveedor =>
+            proveedor.Id.toString() === transaccion_.ActaRecibido.PersonaAsignada.toString();
+            return this.Proveedores.some(criterio) ? this.Proveedores.find(criterio).compuesto : '';
+          })(),
             Validators.required,
           ],
         }),

--- a/src/app/pages/acta-recibido/registro-acta-recibido/registro-acta-recibido.component.html
+++ b/src/app/pages/acta-recibido/registro-acta-recibido/registro-acta-recibido.component.html
@@ -1,7 +1,7 @@
 <nb-card>
   <nb-card-header><h2>{{'GLOBAL.Acta_Recibido.RegistroActa.Title' | translate}}</h2></nb-card-header>
   <nb-card-body [nbSpinner]="Registrando || !firstForm">
-    <form [formGroup]="firstForm" #fform="ngForm" class="step-container">
+    <form *ngIf="firstForm" [formGroup]="firstForm" #fform="ngForm" class="step-container">
         <mat-vertical-stepper [linear]="true" #stepper>
 
           <!-- Datos iniciales -->

--- a/src/app/pages/acta-recibido/registro-acta-recibido/registro-acta-recibido.component.html
+++ b/src/app/pages/acta-recibido/registro-acta-recibido/registro-acta-recibido.component.html
@@ -1,17 +1,7 @@
-<div *ngIf="!firstForm" [nbSpinner]="!firstForm">
-  <nb-card>
-    <nb-card-header>
-    </nb-card-header>
-    <nb-card-body>
-    </nb-card-body>
-  </nb-card>
-</div>
-
-<div class="col-lg-12" *ngIf="firstForm">
-  <form [formGroup]="firstForm" #fform="ngForm" class="step-container">
-    <nb-card>
-      <nb-card-header>{{'GLOBAL.Acta_Recibido.RegistroActa.Title' | translate}}</nb-card-header>
-      <nb-card-body [nbSpinner]="Registrando">
+<nb-card>
+  <nb-card-header>{{'GLOBAL.Acta_Recibido.RegistroActa.Title' | translate}}</nb-card-header>
+  <nb-card-body [nbSpinner]="Registrando || !firstForm">
+    <form [formGroup]="firstForm" #fform="ngForm" class="step-container">
         <mat-vertical-stepper [linear]="true" #stepper>
 
           <!-- Datos iniciales -->
@@ -191,7 +181,6 @@
             </nb-card>
           </mat-step>
         </mat-vertical-stepper>
-      </nb-card-body>
-    </nb-card>
-  </form>
-</div>
+    </form>
+  </nb-card-body>
+</nb-card>

--- a/src/app/pages/acta-recibido/registro-acta-recibido/registro-acta-recibido.component.html
+++ b/src/app/pages/acta-recibido/registro-acta-recibido/registro-acta-recibido.component.html
@@ -1,5 +1,5 @@
 <nb-card>
-  <nb-card-header>{{'GLOBAL.Acta_Recibido.RegistroActa.Title' | translate}}</nb-card-header>
+  <nb-card-header><h2>{{'GLOBAL.Acta_Recibido.RegistroActa.Title' | translate}}</h2></nb-card-header>
   <nb-card-body [nbSpinner]="Registrando || !firstForm">
     <form [formGroup]="firstForm" #fform="ngForm" class="step-container">
         <mat-vertical-stepper [linear]="true" #stepper>

--- a/src/app/pages/acta-recibido/ver-detalle/ver-detalle.component.html
+++ b/src/app/pages/acta-recibido/ver-detalle/ver-detalle.component.html
@@ -1,5 +1,5 @@
 <nb-card>
-  <nb-card-header>{{'GLOBAL.Acta_Recibido.DetalleActa.Title' | translate}}</nb-card-header>
+  <nb-card-header><h2>{{'GLOBAL.Acta_Recibido.DetalleActa.TitleId' | translate: {ID: _ActaId} }}</h2></nb-card-header>
   <nb-card-body [nbSpinner]="!firstForm">
     <form [formGroup]="firstForm" #fform="ngForm" class="step-container" *ngIf="firstForm">
 

--- a/src/app/pages/acta-recibido/ver-detalle/ver-detalle.component.html
+++ b/src/app/pages/acta-recibido/ver-detalle/ver-detalle.component.html
@@ -1,18 +1,8 @@
-<div *ngIf="!firstForm" [nbSpinner]="!firstForm">
-  <nb-card>
-    <nb-card-header>
+<nb-card>
+  <nb-card-header>{{'GLOBAL.Acta_Recibido.DetalleActa.Title' | translate}}</nb-card-header>
+  <nb-card-body [nbSpinner]="!firstForm">
+    <form [formGroup]="firstForm" #fform="ngForm" class="step-container" *ngIf="firstForm">
 
-    </nb-card-header>
-    <nb-card-body>
-
-    </nb-card-body>
-  </nb-card>
-</div>
-<div class="col-lg-12">
-  <form [formGroup]="firstForm" #fform="ngForm" class="step-container" *ngIf="firstForm">
-    <nb-card>
-      <nb-card-header>{{'GLOBAL.Acta_Recibido.DetalleActa.Title' | translate}}</nb-card-header>
-      <nb-card-body>
         <nb-card formGroupName="Formulario1">
           <nb-card-header>{{'GLOBAL.Acta_Recibido.DetalleActa.DatosTitle' | translate}}</nb-card-header>
           <nb-card-body>
@@ -32,6 +22,7 @@
             </div>
           </nb-card-body>
         </nb-card>
+
         <nb-card formArrayName="Formulario2">
           <nb-card-header>{{'GLOBAL.Acta_Recibido.DetalleActa.SoporteTitle' | translate}}</nb-card-header>
           <nb-card-body>
@@ -96,49 +87,31 @@
             </mat-tab-group>
           </nb-card-body>
         </nb-card>
+
         <nb-card>
           <nb-card-header>{{'GLOBAL.Acta_Recibido.DetalleActa.Consolidado' | translate}}</nb-card-header>
           <nb-card-body>
-            <table>
+            <table class="consolidado">
               <tr>
-                <td class="cell-3"></td>
-                <td class="cell-3"></td>
-                <td class="cell-3">{{'GLOBAL.Acta_Recibido.DetalleActa.Subtotal' | translate}}</td>
-                <td class="cell-3"></td>
+                <th class="cell-3">{{'GLOBAL.Acta_Recibido.DetalleActa.Subtotal' | translate}}</th>
                 <td class="cell-3">{{getGranSubtotal() | currency}}</td>
-                <td class="cell-3"></td>
-                <td class="cell-3"></td>
               </tr>
               <tr>
-                <td class="cell-3"></td>
-                <td class="cell-3"></td>
-                <td class="cell-3">{{'GLOBAL.Acta_Recibido.DetalleActa.Descuento' | translate}}</td>
-                <td class="cell-3"></td>
+                <th class="cell-3">{{'GLOBAL.Acta_Recibido.DetalleActa.Descuento' | translate}}</th>
                 <td class="cell-3">{{getGranDescuentos() | currency}}</td>
-                <td class="cell-3"></td>
-                <td class="cell-3"></td>
               </tr>
               <tr>
-                <td class="cell-3"></td>
-                <td class="cell-3"></td>
-                <td class="cell-3">{{'GLOBAL.Acta_Recibido.DetalleActa.ValorIva' | translate}}</td>
-                <td class="cell-3"></td>
+                <th class="cell-3">{{'GLOBAL.Acta_Recibido.DetalleActa.ValorIva' | translate}}</th>
                 <td class="cell-3">{{getGranValorIva() | currency}}</td>
-                <td class="cell-3"></td>
-                <td class="cell-3"></td>
               </tr>
               <tr>
-                <td class="cell-3"></td>
-                <td class="cell-3"></td>
-                <td class="cell-3">{{'GLOBAL.Acta_Recibido.DetalleActa.Total' | translate}}</td>
-                <td class="cell-3"></td>
+                <th class="cell-3">{{'GLOBAL.Acta_Recibido.DetalleActa.Total' | translate}}</th>
                 <td class="cell-3">{{getGranTotal() | currency}}</td>
-                <td class="cell-3"></td>
-                <td class="cell-3"></td>
               </tr>
             </table>
           </nb-card-body>
         </nb-card>
+
         <nb-card formGroupName="Formulario3">
           <nb-card-header>{{'GLOBAL.Acta_Recibido.DetalleActa.DatosAdicionales' | translate}}</nb-card-header>
           <nb-card-body>
@@ -152,7 +125,7 @@
             </div>
           </nb-card-body>
         </nb-card>
-      </nb-card-body>
-    </nb-card>
-  </form>
-</div>
+
+    </form>
+  </nb-card-body>
+</nb-card>

--- a/src/app/pages/acta-recibido/ver-detalle/ver-detalle.component.scss
+++ b/src/app/pages/acta-recibido/ver-detalle/ver-detalle.component.scss
@@ -43,3 +43,8 @@
     float: none;
     text-align: center;
   }
+
+table.consolidado {
+  width: auto;
+  margin: auto;
+}

--- a/src/app/pages/acta-recibido/ver-detalle/ver-detalle.component.ts
+++ b/src/app/pages/acta-recibido/ver-detalle/ver-detalle.component.ts
@@ -187,6 +187,7 @@ export class VerDetalleComponent implements OnInit {
           Soporte: [Soporte.SoporteActa.DocumentoId],
           Elementos: this.fb.array([]),
         });
+        if (Array.isArray(Soporte.Elementos))
         for (const _Elemento of Soporte.Elementos) {
           const Elemento___ = this.fb.group({
             Id: [_Elemento.Id],
@@ -347,34 +348,40 @@ export class VerDetalleComponent implements OnInit {
     }
   }
 
+  private hayElementos(): boolean {
+    return (this.Acta
+    && this.Acta.hasOwnProperty('SoportesActa')
+    && Array.isArray(this.Acta.SoportesActa)
+    && this.Acta.SoportesActa.some(sop => Array.isArray(sop.Elementos))
+    );
+  }
 
   getGranSubtotal() {
-
-    if (this.Acta !== undefined) {
+    if (this.hayElementos()) {
       return this.Acta.SoportesActa.map(t => t.Elementos.map(w => w.ValorTotal).reduce((acc, value) => acc + value)).toString();
     } else {
       return '0';
     }
   }
-  getGranDescuentos() {
 
-    if (this.Acta !== undefined) {
+  getGranDescuentos() {
+    if (this.hayElementos()) {
       return this.Acta.SoportesActa.map(t => t.Elementos.map(w => w.Descuento).reduce((acc, value) => acc + value)).toString();
     } else {
       return '0';
     }
   }
-  getGranValorIva() {
 
-    if (this.Acta !== undefined) {
+  getGranValorIva() {
+    if (this.hayElementos()) {
       return this.Acta.SoportesActa.map(t => t.Elementos.map(w => w.ValorIva).reduce((acc, value) => acc + value)).toString();
     } else {
       return '0';
     }
   }
-  getGranTotal() {
 
-    if (this.Acta !== undefined) {
+  getGranTotal() {
+    if (this.hayElementos()) {
       return this.Acta.SoportesActa.map(t => t.Elementos.map(w => w.ValorFinal).reduce((acc, value) => acc + value)).toString();
     } else {
       return '0';

--- a/src/app/pages/acta-recibido/ver-detalle/ver-detalle.component.ts
+++ b/src/app/pages/acta-recibido/ver-detalle/ver-detalle.component.ts
@@ -69,6 +69,8 @@ export class VerDetalleComponent implements OnInit {
     this.loadLists();
   }
 
+  private actaCargada: boolean = false;
+
   // Modelos
 
   Acta__: ActaRecibido;
@@ -141,14 +143,20 @@ export class VerDetalleComponent implements OnInit {
           this.Dependencias !== undefined && this.Sedes !== undefined &&
           this._ActaId !== undefined) {
           // console.log(this._ActaId);
+          this.cargarActa();
+        }
+      },
+    );
+  }
+
+  private cargarActa() {
+    if (!this.actaCargada) {
           this.Actas_Recibido.getTransaccionActa(this._ActaId).subscribe(Acta => {
             // console.log(Acta);
             this.Cargar_Formularios(Acta[0]);
             // console.log('ok');
           });
-        }
-      },
-    );
+    }
   }
 
   T_V(valor: string): string {

--- a/src/app/pages/acta-recibido/verificacion-acta-recibido/verificacion-acta-recibido.component.html
+++ b/src/app/pages/acta-recibido/verificacion-acta-recibido/verificacion-acta-recibido.component.html
@@ -1,5 +1,5 @@
 <nb-card>
-  <nb-card-header>{{'GLOBAL.Acta_Recibido.VerificacionActa.Title' | translate}}</nb-card-header>
+  <nb-card-header><h2>{{'GLOBAL.Acta_Recibido.VerificacionActa.TitleId' | translate: {ID: _ActaId} }}</h2></nb-card-header>
   <nb-card-body [nbSpinner]="!firstForm">
     <form [formGroup]="firstForm" #fform="ngForm" class="step-container" *ngIf="firstForm">
 

--- a/src/app/pages/acta-recibido/verificacion-acta-recibido/verificacion-acta-recibido.component.html
+++ b/src/app/pages/acta-recibido/verificacion-acta-recibido/verificacion-acta-recibido.component.html
@@ -1,18 +1,8 @@
-<div *ngIf="!firstForm" [nbSpinner]="!firstForm">
-  <nb-card>
-    <nb-card-header>
+<nb-card>
+  <nb-card-header>{{'GLOBAL.Acta_Recibido.VerificacionActa.Title' | translate}}</nb-card-header>
+  <nb-card-body [nbSpinner]="!firstForm">
+    <form [formGroup]="firstForm" #fform="ngForm" class="step-container" *ngIf="firstForm">
 
-    </nb-card-header>
-    <nb-card-body>
-
-    </nb-card-body>
-  </nb-card>
-</div>
-<div class="col-lg-12">
-  <form [formGroup]="firstForm" #fform="ngForm" class="step-container" *ngIf="firstForm">
-    <nb-card>
-      <nb-card-header>{{'GLOBAL.Acta_Recibido.VerificacionActa.Title' | translate}}</nb-card-header>
-      <nb-card-body>
         <nb-card formGroupName="Formulario1">
           <nb-card-header>{{'GLOBAL.Acta_Recibido.VerificacionActa.DatosTitle' | translate}}</nb-card-header>
           <nb-card-body>
@@ -32,6 +22,7 @@
             </div>
           </nb-card-body>
         </nb-card>
+
         <nb-card formArrayName="Formulario2">
           <nb-card-header>{{'GLOBAL.Acta_Recibido.VerificacionActa.SoporteTitle' | translate}}</nb-card-header>
           <nb-card-body>
@@ -90,7 +81,7 @@
                       <div class="pre-scrollable">
                         <ngx-verificacion-elementos [DatosRecibidos]='soporte.get("Elementos").value' [mode]='"multi"' (DatosEnviados)="Verificar_Tabla($event, i)"></ngx-verificacion-elementos>
                       </div>
-                      
+
                     </nb-card-body>
                   </nb-card>
                 </div>
@@ -99,49 +90,31 @@
             </mat-tab-group>
           </nb-card-body>
         </nb-card>
+
         <nb-card>
           <nb-card-header>{{'GLOBAL.Acta_Recibido.VerificacionActa.Consolidado' | translate}}</nb-card-header>
           <nb-card-body>
-            <table class="table text-center">
+            <table class="consolidado">
               <tr>
-                <td class="cell-3"></td>
-                <td class="cell-3"></td>
-                <td class="cell-3">{{'GLOBAL.Acta_Recibido.VerificacionActa.Subtotal' | translate}}</td>
-                <td class="cell-3"></td>
+                <th class="cell-3">{{'GLOBAL.Acta_Recibido.VerificacionActa.Subtotal' | translate}}</th>
                 <td class="cell-3">{{getGranSubtotal() | currency}}</td>
-                <td class="cell-3"></td>
-                <td class="cell-3"></td>
               </tr>
               <tr>
-                <td class="cell-3"></td>
-                <td class="cell-3"></td>
-                <td class="cell-3">{{'GLOBAL.Acta_Recibido.VerificacionActa.Descuento' | translate}}</td>
-                <td class="cell-3"></td>
+                <th class="cell-3">{{'GLOBAL.Acta_Recibido.VerificacionActa.Descuento' | translate}}</th>
                 <td class="cell-3">{{getGranDescuentos() | currency}}</td>
-                <td class="cell-3"></td>
-                <td class="cell-3"></td>
               </tr>
               <tr>
-                <td class="cell-3"></td>
-                <td class="cell-3"></td>
-                <td class="cell-3">{{'GLOBAL.Acta_Recibido.VerificacionActa.ValorIva' | translate}}</td>
-                <td class="cell-3"></td>
+                <th class="cell-3">{{'GLOBAL.Acta_Recibido.VerificacionActa.ValorIva' | translate}}</th>
                 <td class="cell-3">{{getGranValorIva() | currency}}</td>
-                <td class="cell-3"></td>
-                <td class="cell-3"></td>
               </tr>
               <tr>
-                <td class="cell-3"></td>
-                <td class="cell-3"></td>
-                <td class="cell-3">{{'GLOBAL.Acta_Recibido.VerificacionActa.Total' | translate}}</td>
-                <td class="cell-3"></td>
+                <th class="cell-3">{{'GLOBAL.Acta_Recibido.VerificacionActa.Total' | translate}}</th>
                 <td class="cell-3">{{getGranTotal() | currency}}</td>
-                <td class="cell-3"></td>
-                <td class="cell-3"></td>
               </tr>
             </table>
           </nb-card-body>
         </nb-card>
+
         <nb-card formGroupName="Formulario3">
           <nb-card-header>{{'GLOBAL.Acta_Recibido.VerificacionActa.DatosAdicionales' | translate}}</nb-card-header>
           <nb-card-body>
@@ -163,7 +136,7 @@
             </div>
           </nb-card-footer>
         </nb-card>
-      </nb-card-body>
-    </nb-card>
-  </form>
-</div>
+
+    </form>
+  </nb-card-body>
+</nb-card>

--- a/src/app/pages/acta-recibido/verificacion-acta-recibido/verificacion-acta-recibido.component.scss
+++ b/src/app/pages/acta-recibido/verificacion-acta-recibido/verificacion-acta-recibido.component.scss
@@ -2,14 +2,14 @@
     display: flex !important;
     height: 0 !important;
   }
-  
+
   :host /deep/ ng2-st-tbody-custom a.ng2-smart-action.ng2-smart-action-custom-custom {
     display: inline-block;
     width: 30px;
     text-align: center;
     font-size: 1.1em;
   }
-  
+
   :host /deep/ ng2-st-tbody-custom a.ng2-smart-action.ng2-smart-action-custom-custom:hover {
     color: #5dcfe3;
   }
@@ -43,4 +43,8 @@
     float: none;
     text-align: center;
   }
-  
+
+table.consolidado {
+  width: auto;
+  margin: auto;
+}

--- a/src/app/pages/acta-recibido/verificacion-acta-recibido/verificacion-acta-recibido.component.ts
+++ b/src/app/pages/acta-recibido/verificacion-acta-recibido/verificacion-acta-recibido.component.ts
@@ -84,6 +84,8 @@ export class VerificacionActaRecibidoComponent implements OnInit {
   bandera2: boolean;
   respuesta: any;
 
+  private actaCargada: boolean = false;
+
   constructor(
     private translate: TranslateService,
     private router: Router,
@@ -138,15 +140,21 @@ export class VerificacionActaRecibidoComponent implements OnInit {
           this.Dependencias !== undefined && this.Sedes !== undefined &&
           this._ActaId !== undefined && this.respuesta === undefined) {
           // console.log(this._ActaId);
+          this.cargarActa();
+        }
+      },
+    );
+  }
+
+  private cargarActa() {
+    if (!this.actaCargada) {
           this.Actas_Recibido.getTransaccionActa(this._ActaId).subscribe(Acta => {
             // console.log(Acta);
             this.respuesta = true;
             this.Cargar_Formularios(Acta[0]);
             // console.log('ok');
           });
-        }
-      },
-    );
+    }
   }
 
   T_V(valor: string): string {

--- a/src/app/pages/acta-recibido/verificacion-acta-recibido/verificacion-acta-recibido.component.ts
+++ b/src/app/pages/acta-recibido/verificacion-acta-recibido/verificacion-acta-recibido.component.ts
@@ -599,38 +599,45 @@ export class VerificacionActaRecibidoComponent implements OnInit {
       }
     });
   }
-  getGranSubtotal() {
 
-    if (this.Acta !== undefined) {
+  private hayElementos(): boolean {
+    return (this.Acta
+    && this.Acta.hasOwnProperty('SoportesActa')
+    && Array.isArray(this.Acta.SoportesActa)
+    && this.Acta.SoportesActa.some(sop => Array.isArray(sop.Elementos))
+    );
+  }
+
+  getGranSubtotal() {
+    if (this.hayElementos()) {
       return this.Acta.SoportesActa.map(t => t.Elementos.map(w => w.ValorTotal).reduce((acc, value) => acc + value)).toString();
     } else {
       return '0';
     }
   }
-  getGranDescuentos() {
 
-    if (this.Acta !== undefined) {
+  getGranDescuentos() {
+    if (this.hayElementos()) {
       return this.Acta.SoportesActa.map(t => t.Elementos.map(w => w.Descuento).reduce((acc, value) => acc + value)).toString();
     } else {
       return '0';
     }
   }
-  getGranValorIva() {
 
-    if (this.Acta !== undefined) {
+  getGranValorIva() {
+    if (this.hayElementos()) {
       return this.Acta.SoportesActa.map(t => t.Elementos.map(w => w.ValorIva).reduce((acc, value) => acc + value)).toString();
     } else {
       return '0';
     }
   }
-  getGranTotal() {
 
-    if (this.Acta !== undefined) {
+  getGranTotal() {
+    if (this.hayElementos()) {
       return this.Acta.SoportesActa.map(t => t.Elementos.map(w => w.ValorFinal).reduce((acc, value) => acc + value)).toString();
     } else {
       return '0';
     }
   }
-  volver() {
-  }
+
 }

--- a/src/app/pages/acta-recibido/verificacion-acta-recibido/verificacion-acta-recibido.component.ts
+++ b/src/app/pages/acta-recibido/verificacion-acta-recibido/verificacion-acta-recibido.component.ts
@@ -197,12 +197,28 @@ export class VerificacionActaRecibidoComponent implements OnInit {
           Elementos: this.fb.array([]),
         });
         this.Verificar_tabla.push(false);
+
+        if (Array.isArray(Soporte.Elementos))
         for (const _Elemento of Soporte.Elementos) {
 
           const Elemento___ = this.fb.group({
             Id: [_Elemento.Id],
             TipoBienId: [
-              this.Tipos_Bien.find(bien => bien.Id.toString() === _Elemento.TipoBienId.Id.toString()).Nombre,
+              (() => {
+                const criterio = bien => {
+                  if (bien.hasOwnProperty('Id')
+                  && _Elemento.hasOwnProperty('TipoBienId') && _Elemento.TipoBienId
+                  && _Elemento.TipoBienId.hasOwnProperty('Id') && _Elemento.TipoBienId.Id) {
+                    return bien.Id.toString() === _Elemento.TipoBienId.Id.toString();
+                  } else {
+                    return false;
+                  }
+                };
+                if (Array.isArray(this.Tipos_Bien) && this.Tipos_Bien.some(criterio)) {
+                  return this.Tipos_Bien.find(criterio).Nombre;
+                }
+                return undefined;
+              })(),
             ],
             SubgrupoCatalogoId: [_Elemento.SubgrupoCatalogoId],
             Nombre: [_Elemento.Nombre],

--- a/src/app/pages/acta-recibido/verificacion-elementos/verificacion-elementos.component.ts
+++ b/src/app/pages/acta-recibido/verificacion-elementos/verificacion-elementos.component.ts
@@ -229,7 +229,7 @@ export class VerificacionElementosComponent implements OnInit {
         if (datos[index].TipoBienId === 'Consumo Controlado' && Object.keys(this.ConsumoControlado[0]).length !== 0) {
           elemento.SubgrupoCatalogoId = this.ConsumoControlado.find(x => x.SubgrupoId.Id === datos[index].SubgrupoCatalogoId).SubgrupoId;
         }
-        if (datos[index].TipoBienId.Id === 'Devolutivo' && Object.keys(this.Devolutivo[0]).length !== 0) {
+        if (datos[index].TipoBienId === 'Devolutivo' && Object.keys(this.Devolutivo[0]).length !== 0) {
           elemento.SubgrupoCatalogoId = this.Devolutivo.find(x => x.SubgrupoId.Id === datos[index].SubgrupoCatalogoId).SubgrupoId;
         }
         this.Datos.push(elemento);

--- a/src/app/pages/catalogo-bienes/consulta-catalogo/consulta-catalogo.component.html
+++ b/src/app/pages/catalogo-bienes/consulta-catalogo/consulta-catalogo.component.html
@@ -1,6 +1,6 @@
 <nb-card>
   <nb-card-header>
-    <h1>{{'GLOBAL.consultar_catalogo' | translate}}</h1>
+    <h2>{{'GLOBAL.consultar_catalogo' | translate}}</h2>
   </nb-card-header>
   <nb-card-body>
 

--- a/src/app/pages/catalogo-bienes/inactivar-grupo/inactivar-grupo.component.html
+++ b/src/app/pages/catalogo-bienes/inactivar-grupo/inactivar-grupo.component.html
@@ -1,6 +1,6 @@
 <nb-card>
   <nb-card-header>
-    <h1>{{'GLOBAL.inactivar_grupos_subgrupos' | translate}}</h1>
+    <h2>{{'GLOBAL.inactivar_grupos_subgrupos' | translate}}</h2>
   </nb-card-header>
   <nb-card-body [nbSpinner]="cargando_catalogos">
         <h5>{{'GLOBAL.catalogo.uno' | translate}}</h5>

--- a/src/app/pages/catalogo-bienes/inactivar-grupo/inactivar-grupo.component.html
+++ b/src/app/pages/catalogo-bienes/inactivar-grupo/inactivar-grupo.component.html
@@ -1,5 +1,4 @@
-<div class="row">
-<nb-card class="col">
+<nb-card>
   <nb-card-header>
     <h1>{{'GLOBAL.inactivar_grupos_subgrupos' | translate}}</h1>
   </nb-card-header>
@@ -14,4 +13,3 @@
           ></ngx-arbol>
   </nb-card-body>
 </nb-card>
-</div>

--- a/src/app/pages/catalogo-bienes/registro-catalogo/registro-catalogo.component.html
+++ b/src/app/pages/catalogo-bienes/registro-catalogo/registro-catalogo.component.html
@@ -1,7 +1,7 @@
 <div class="row">
   <nb-card class="col">
     <nb-card-header>
-      {{'GLOBAL.catalogo.uno' | translate}}
+      <h2>{{'GLOBAL.catalogo.uno' | translate}}</h2>
     </nb-card-header>
     <nb-card-body [nbSpinner]="cargando_catalogos">
         <select class="form-control mb-4" (change)="onChange($event.target.value)">

--- a/src/app/pages/catalogo-bienes/registro-cuentas-catalogo/registro-cuentas-catalogo.component.html
+++ b/src/app/pages/catalogo-bienes/registro-cuentas-catalogo/registro-cuentas-catalogo.component.html
@@ -3,7 +3,7 @@
 
   <nb-card class="col">
     <nb-card-header>
-      {{'GLOBAL.catalogo.uno' | translate}}
+      <h2>{{'GLOBAL.catalogo.uno' | translate}}</h2>
     </nb-card-header>
     <nb-card-body [nbSpinner]="cargando_catalogos">
         <select class="form-control mb-4" (change)="onChange($event.target.value)">

--- a/src/app/pages/catalogo-bienes/registro-elementos/registro-elementos.component.html
+++ b/src/app/pages/catalogo-bienes/registro-elementos/registro-elementos.component.html
@@ -1,7 +1,7 @@
 <div class="row">
 <nb-card class="col">
   <nb-card-header>
-    <h1>{{'GLOBAL.registro_elementos' | translate}}</h1>
+    <h2>{{'GLOBAL.registro_elementos' | translate}}</h2>
   </nb-card-header>
   <nb-card-body [nbSpinner]="cargando_catalogos">
         <h5>{{'GLOBAL.catalogo.uno' | translate}}</h5>

--- a/src/app/pages/catalogo/list-catalogo/list-catalogo.component.html
+++ b/src/app/pages/catalogo/list-catalogo/list-catalogo.component.html
@@ -1,5 +1,5 @@
   <nb-card>
-    <nb-card-header><h1>{{ 'GLOBAL.catalogo.lista' | translate }}</h1></nb-card-header>
+    <nb-card-header><h2>{{ 'GLOBAL.catalogo.lista' | translate }}</h2></nb-card-header>
     <nb-card-body [nbSpinner]="cargando">
         <toaster-container [toasterconfig]="config"></toaster-container>
           <ng2-smart-table [settings]="settings" [source]="source"

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -136,6 +136,7 @@
       },
       "EdicionActa": {
         "Title": "Edit Receipt Certificate",
+        "TitleId": "Edit Receipt Certificate No.{{ID}}",
         "DatosTitle": "Initial Data",
         "Sede": "Campus",
         "Dependencia": "Dependence",
@@ -182,6 +183,7 @@
       },
       "DetalleActa": {
         "Title": "Receipt Certificate Detail",
+        "TitleId": "Receipt Certificate No.{{ID}} Detail",
         "DatosTitle": "Initial Data",
         "Sede": "Campus",
         "Dependencia": "Dependence",
@@ -221,6 +223,7 @@
       },
       "VerificacionActa": {
         "Title": "Verify Receipt Certificate",
+        "TitleId": "Verify Receipt Certificate No.{{ID}}",
         "DatosTitle": "Initial Data",
         "Sede": "Campus",
         "Dependencia": "Dependence",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -136,6 +136,7 @@
       },
       "EdicionActa":{
         "Title": "Editar Acta de Recibido",
+        "TitleId": "Editar Acta de Recibido #{{ID}}",
         "DatosTitle":"Datos Iniciales",
         "Sede":"Sede",
         "Dependencia":"Dependencia",
@@ -182,6 +183,7 @@
       },
       "DetalleActa":{
         "Title": "Detalle Acta de Recibido",
+        "TitleId": "Detalle Acta de Recibido #{{ID}}",
         "DatosTitle":"Datos Iniciales",
         "Sede":"Sede",
         "Dependencia":"Dependencia",
@@ -221,6 +223,7 @@
       },
       "VerificacionActa":{
         "Title": "Detalle Acta de Recibido",
+        "TitleId": "Detalle Acta de Recibido #{{ID}}",
         "DatosTitle":"Datos Iniciales",
         "Sede":"Sede",
         "Dependencia":"Dependencia",

--- a/src/index.html
+++ b/src/index.html
@@ -6,8 +6,7 @@
   <title>ARKA II - Universidad Distrital Francisco José de Caldas</title>
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" type="image/png" href="favicon.png">
-  <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link rel="icon" href="assets/images/isotipo arkaII.svg">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons"rel="stylesheet">
 </head>
 


### PR DESCRIPTION
Relacionado con #469. Se arregla principalmente lo siguiente:

- Parpadeo al ver/validar un acta
- Bugs que no dejan ir a ver/validar ciertas actas
- Feature: Antes, al ver/editar/validar un acta, no se sabía el # del acta. Se colocó en el título:
  ![image](https://user-images.githubusercontent.com/6588872/107703138-417d9280-6c89-11eb-9555-aef22a73d0d2.png)
- En 11981b7 se agregó un dialogo de confirmación al realizar carga masiva en caso de detectarse elementos. Pero en caso de no haber, no estaba dejando, lo que se corrigió en 3f23e34
