### PR TITLE
Fix/id entradas

### DIFF
--- a/src/app/helpers/terceros/tercerosHelper.ts
+++ b/src/app/helpers/terceros/tercerosHelper.ts
@@ -12,19 +12,25 @@ export class TercerosHelper {
         private pUpManager: PopUpManager) { }
 
     /**
-      * Elementos get
-      * Conversion Archivo Post
+      * Trae la lista de terceros activos
       * If the response has errors in the OAS API it should show a popup message with an error.
       * If the response is successs, it returns the object's data.
+      * @param query to Terceros CRUD API
       * @returns  <Observable> data of the object registered at the DB. undefined if the request has errors
      */
-    public getProveedor(nombre) {
-        this.rqManager.setPath('TERCEROS');
-        return this.rqManager.get('tercero/' + nombre + '').pipe(
+    public getTerceros(query: string = '') {
+        this.rqManager.setPath('TERCEROS_SERVICE');
+        let endpoint = 'tercero?limit=-1';
+        endpoint += '&fields=Id,NombreCompleto';
+        endpoint += '&query=Activo:true';
+        if (query) {
+            endpoint += ',' + query;
+        }
+        return this.rqManager.get(endpoint).pipe(
             map(
                 (res) => {
-                    if (res === 'error') {
-                        this.pUpManager.showErrorAlert('No se encontro ningun nombre de proovedor');
+                    if (res === 'error' || !Array.isArray(res) || !res.some(t => Object.keys(t).length > 0)) {
+                        this.pUpManager.showErrorAlert('No hay terceros disponibles');
                         return undefined;
                     }
                     return res;

--- a/src/app/pages/acta-recibido/consulta-acta-recibido/consulta-acta-recibido.component.ts
+++ b/src/app/pages/acta-recibido/consulta-acta-recibido/consulta-acta-recibido.component.ts
@@ -235,7 +235,7 @@ export class ConsultaActaRecibidoComponent implements OnInit {
           },
         },
         UbicacionId: {
-          title: this.translate.instant('GLOBAL.Acta_Recibido.ConsultaActas.UbicacionHeader'),
+          title: this.translate.instant('GLOBAL.dependencia'),
           valuePrepareFunction: (value: any) => {
             return value;
           },

--- a/src/app/pages/entradas/consulta-entrada/consulta-entrada.component.ts
+++ b/src/app/pages/entradas/consulta-entrada/consulta-entrada.component.ts
@@ -90,9 +90,11 @@ export class ConsultaEntradaComponent implements OnInit {
       },
       mode: 'external',
       columns: {
+        /*
         Id: {
           title: 'ID',
         },
+        // */
         Consecutivo: {
           title: this.translate.instant('GLOBAL.consecutivo'),
         },

--- a/src/app/pages/entradas/registro/registro.component.ts
+++ b/src/app/pages/entradas/registro/registro.component.ts
@@ -42,10 +42,16 @@ export class RegistroComponent implements OnInit {
       'EEP', 'ET',
       // */
     ];
+  }
+
+  ngOnInit() {
     this.loadTablaSettings();
     this.loadActas();
     this.listService.findClases();
     this.listService.findImpuestoIVA();
+    this.translate.onLangChange.subscribe((event: LangChangeEvent) => { // Live reload
+      this.loadTablaSettings();
+    });
   }
 
   loadTablaSettings() {
@@ -122,12 +128,6 @@ export class RegistroComponent implements OnInit {
         },
       },
     };
-  }
-
-  ngOnInit() {
-    this.translate.onLangChange.subscribe((event: LangChangeEvent) => { // Live reload
-      this.loadTablaSettings();
-    });
   }
 
   loadActas(): void {

--- a/src/app/pages/entradas/registro/registro.component.ts
+++ b/src/app/pages/entradas/registro/registro.component.ts
@@ -1,8 +1,10 @@
 import { Component, OnInit } from '@angular/core';
 import { LocalDataSource } from 'ngx-smart-table';
 import { ActaRecibido, ActaRecibidoUbicacion } from '../../../@core/data/models/acta_recibido/acta_recibido';
+import { Tercero } from '../../../@core/data/models/terceros';
 import { PopUpManager } from '../../../managers/popUpManager';
 import { ActaRecibidoHelper } from '../../../helpers/acta_recibido/actaRecibidoHelper';
+import { TercerosHelper } from '../../../helpers/terceros/tercerosHelper';
 import { LangChangeEvent, TranslateService } from '@ngx-translate/core';
 import { ListService } from '../../../@core/store/services/list.service';
 import { Store } from '@ngrx/store';
@@ -25,12 +27,16 @@ export class RegistroComponent implements OnInit {
   settings: any;
   opcionEntrada: string;
 
+  private terceros: Partial<Tercero>[];
+  private actas: any[];
+
   constructor(
     private actaRecibidoHelper: ActaRecibidoHelper,
     private pUpManager: PopUpManager,
     private translate: TranslateService,
     private listService: ListService,
     private store: Store<IAppState>,
+    private tercerosHelper: TercerosHelper,
   ) {
     this.source = new LocalDataSource();
     this.actaSeleccionada = '';
@@ -52,6 +58,7 @@ export class RegistroComponent implements OnInit {
     this.translate.onLangChange.subscribe((event: LangChangeEvent) => { // Live reload
       this.loadTablaSettings();
     });
+    this.loadTerceros();
   }
 
   loadTablaSettings() {
@@ -134,10 +141,36 @@ export class RegistroComponent implements OnInit {
     this.actaRecibidoHelper.getActasRecibido().subscribe(res => {
       if (Array.isArray(res) && res.length !== 0) {
         const data = <Array<ActaRecibidoUbicacion>>res;
-        this.source.load(data);
-        this.mostrar = true;
+        this.actas = data;
+        this.mostrarData();
+        // console.log({actas: this.actas});
       }
     });
+  }
+
+  private loadTerceros(): void {
+    this.tercerosHelper.getTerceros().subscribe(terceros => {
+      this.terceros = terceros;
+      this.mostrarData();
+      // console.log({terceros: this.terceros});
+    });
+  }
+
+  private mostrarData(): void {
+    if (!this.mostrar
+    && this.actas && this.actas.length
+    && this.terceros && this.terceros.length) {
+      this.source.load(this.actas.map(acta => {
+        const buscar = (tercero: Tercero) => tercero.Id === acta.RevisorId;
+        let nombre = '';
+        if (this.terceros.some(buscar)) {
+          nombre = this.terceros.find(buscar).NombreCompleto;
+        }
+        acta.RevisorId = nombre;
+        return acta;
+      }));
+      this.mostrar = true;
+    }
   }
 
   onCustom(event) {


### PR DESCRIPTION
Avance de #505. En orden de los commit

- De Entradas>Consulta, se ocultó la columna ID, ya que:
  - Este ID corresponde al de la entrada. Para IDentificar cada entrada se usará el consecutivo, no su ID directamente
  - Si hay un "ID" que realmente interese, sería el del Acta asociada, que se muestra actualmente en la columna "Acta Recibido"
- En Actas>Consulta, la columna "Ubicacion" corresponde realmente a la Dependencia, se actualizó para que se muestre "Dependencia" y no "Ubicacion" (Puede ser necesario actualizar lo que retorna el MID para dar claridad al respecto, dado que se está retornando como "Ubicacion")
- (Luego de agregar un helper adicional para traer los terceros al cliente, que acepta un _query_) En Entradas>Registrar, en la columna Revisor se estaba mostrando el ID del Revisor (tabla tercero, de Terceros CRUD) pero no se resolvía su valor. Ahora se muestra el nombre completo en vez del ID