### PR TITLE
fix: Bug que no permite que la fecha del soporte se pueda limpiar

### DIFF
--- a/src/app/pages/acta-recibido/edicion-acta-recibido/edicion-acta-recibido.component.html
+++ b/src/app/pages/acta-recibido/edicion-acta-recibido/edicion-acta-recibido.component.html
@@ -50,13 +50,13 @@
                         </mat-option>
                       </mat-autocomplete>
                       <p class="campo"
-                        *ngIf="firstForm.get('Formulario1.Contratista').errors && firstForm.get('Formulario1.Contratista').errors.required ? true : false">
+                        *ngIf="firstForm.get('Formulario1.Contratista').errors && firstForm.get('Formulario1.Contratista').errors.required">
                         {{'GLOBAL.Errores.ErrorRequerido' | translate}}</p>
                       <p class="campo"
-                        *ngIf="firstForm.get('Formulario1.Contratista').errors && firstForm.get('Formulario1.Contratista').errors.errorLongitudMinima ? true : false">
+                        *ngIf="firstForm.get('Formulario1.Contratista').errors && firstForm.get('Formulario1.Contratista').errors.errorLongitudMinima">
                         {{'GLOBAL.Errores.ErrorMinLength' | translate : {NUM : '4'} }}</p>
                       <p class="campo"
-                        *ngIf="firstForm.get('Formulario1.Contratista').errors && firstForm.get('Formulario1.Contratista').errors.terceroNoValido ? true : false">
+                        *ngIf="firstForm.get('Formulario1.Contratista').errors && firstForm.get('Formulario1.Contratista').errors.terceroNoValido">
                         {{'GLOBAL.Errores.ErrorTercero' | translate}}</p>
                   </div>
                 </div>
@@ -102,13 +102,13 @@
                                   </mat-option>
                                 </mat-autocomplete>
                                 <p class="campo"
-                                  *ngIf="soporte.get('Proveedor').errors && soporte.get('Proveedor').errors.required ? true : false">
+                                  *ngIf="soporte.get('Proveedor').errors && soporte.get('Proveedor').errors.required">
                                   {{'GLOBAL.Errores.ErrorRequerido' | translate}}</p>
                                 <p class="campo"
-                                  *ngIf="soporte.get('Proveedor').errors && soporte.get('Proveedor').errors.errorLongitudMinima ? true : false">
+                                  *ngIf="soporte.get('Proveedor').errors && soporte.get('Proveedor').errors.errorLongitudMinima">
                                   {{'GLOBAL.Errores.ErrorMinLength' | translate : {NUM : '4'} }}</p>
                                 <p class="campo"
-                                  *ngIf="soporte.get('Proveedor').errors && soporte.get('Proveedor').errors.terceroNoValido ? true : false">
+                                  *ngIf="soporte.get('Proveedor').errors && soporte.get('Proveedor').errors.terceroNoValido">
                                   {{'GLOBAL.Errores.ErrorTercero' | translate}}</p>
                               </div>
                               <div class="form-group col-sm">
@@ -131,10 +131,10 @@
                                   <nb-datepicker #formpicker [max]="TodaysDate" (dateChange)="usarLocalStorage()"></nb-datepicker>
                                 </div>
                                 <p class="campo"
-                                  *ngIf="soporte.get('Fecha_Factura').errors && soporte.get('Fecha_Factura').errors.required ? true : false">
+                                  *ngIf="soporte.get('Fecha_Factura').errors && soporte.get('Fecha_Factura').errors.required">
                                   {{'GLOBAL.Errores.ErrorRequerido' | translate}}</p>
                                 <p class="campo"
-                                  *ngIf="soporte.get('Fecha_Factura').errors && soporte.get('Fecha_Factura').errors.fecha ? true : false">
+                                  *ngIf="soporte.get('Fecha_Factura').errors && soporte.get('Fecha_Factura').errors.fecha">
                                   {{'GLOBAL.Errores.ErrorFecha' | translate}}</p>
                               </div>
                             </div>

--- a/src/app/pages/acta-recibido/edicion-acta-recibido/edicion-acta-recibido.component.html
+++ b/src/app/pages/acta-recibido/edicion-acta-recibido/edicion-acta-recibido.component.html
@@ -127,7 +127,7 @@
                                   <input nbInput (click)="usarLocalStorage()"
                                     placeholder="{{'GLOBAL.Acta_Recibido.EdicionActa.FechaFiltro' | translate}}"
                                     class="form-control" [nbDatepicker]="formpicker" (keyup)="usarLocalStorage()"
-                                    formControlName="Fecha_Factura">
+                                    formControlName="Fecha_Factura" (keyup.Backspace)="clear()">
                                   <nb-datepicker #formpicker [max]="TodaysDate" (dateChange)="usarLocalStorage()"></nb-datepicker>
                                 </div>
                                 <p class="campo" *ngIf="soporte.get('Fecha_Factura').invalid">

--- a/src/app/pages/acta-recibido/edicion-acta-recibido/edicion-acta-recibido.component.html
+++ b/src/app/pages/acta-recibido/edicion-acta-recibido/edicion-acta-recibido.component.html
@@ -130,7 +130,11 @@
                                     formControlName="Fecha_Factura" (keyup.Backspace)="clear()">
                                   <nb-datepicker #formpicker [max]="TodaysDate" (dateChange)="usarLocalStorage()"></nb-datepicker>
                                 </div>
-                                <p class="campo" *ngIf="soporte.get('Fecha_Factura').invalid">
+                                <p class="campo"
+                                  *ngIf="soporte.get('Fecha_Factura').errors && soporte.get('Fecha_Factura').errors.required ? true : false">
+                                  {{'GLOBAL.Errores.ErrorRequerido' | translate}}</p>
+                                <p class="campo"
+                                  *ngIf="soporte.get('Fecha_Factura').errors && soporte.get('Fecha_Factura').errors.fecha ? true : false">
                                   {{'GLOBAL.Errores.ErrorFecha' | translate}}</p>
                               </div>
                             </div>

--- a/src/app/pages/acta-recibido/edicion-acta-recibido/edicion-acta-recibido.component.ts
+++ b/src/app/pages/acta-recibido/edicion-acta-recibido/edicion-acta-recibido.component.ts
@@ -503,10 +503,10 @@ export class EdicionActaRecibidoComponent implements OnInit {
           Fecha_Factura: [
             {
               value: new Date(Soporte.SoporteActa.FechaSoporte) > new Date('1945') ?
-              Soporte.SoporteActa.FechaSoporte.toString() : '',
+                this.dateService.parse(Soporte.SoporteActa.FechaSoporte.toString(), 'MM dd yyyy') : '',
               disabled: !this.getPermisoEditar(this.permisos.Acta),
             },
-            { validators: this.actaRegistrada ? [] : [Validators.required] }],
+            { validators: this.checkDate() }],
           Soporte: [Soporte.SoporteActa.DocumentoId, Validators.required],
         });
         this.Validador[index] = true;
@@ -1224,7 +1224,8 @@ export class EdicionActaRecibidoComponent implements OnInit {
 
   clear() {
     this.firstForm.get('Formulario2')['controls'][0].get('Fecha_Factura').patchValue('');
-    this.firstForm.get('Formulario2')['controls'][0].get('Fecha_Factura').setErrors(null);
+    this.firstForm.get('Formulario2')['controls'][0].get('Fecha_Factura').setValidators(this.checkDate());
+    this.firstForm.get('Formulario2')['controls'][0].get('Fecha_Factura').updateValueAndValidity();
   }
 
   private validarTercero(): ValidatorFn {
@@ -1245,5 +1246,13 @@ export class EdicionActaRecibidoComponent implements OnInit {
       control.get('Formulario3').valid);
     errors ? this.errores.set('formularios', true) : this.errores.delete('formularios');
     return errors ? { formularios: true } : null;
+  }
+
+  private checkDate(): ValidatorFn {
+    return (control: AbstractControl): ValidationErrors | null => {
+      const invalid = control.value === null;
+      const empty = control.value === '';
+      return invalid ? { fecha : true } : !this.actaRegistrada && empty ? { required : true} : null;
+    };
   }
 }

--- a/src/app/pages/acta-recibido/edicion-acta-recibido/edicion-acta-recibido.component.ts
+++ b/src/app/pages/acta-recibido/edicion-acta-recibido/edicion-acta-recibido.component.ts
@@ -1222,6 +1222,11 @@ export class EdicionActaRecibidoComponent implements OnInit {
     }
   }
 
+  clear() {
+    this.firstForm.get('Formulario2')['controls'][0].get('Fecha_Factura').patchValue('');
+    this.firstForm.get('Formulario2')['controls'][0].get('Fecha_Factura').setErrors(null);
+  }
+  
   private validarTercero(): ValidatorFn {
     return (control: AbstractControl): ValidationErrors | null => {
       const valor = control.value;

--- a/src/app/pages/acta-recibido/edicion-acta-recibido/edicion-acta-recibido.component.ts
+++ b/src/app/pages/acta-recibido/edicion-acta-recibido/edicion-acta-recibido.component.ts
@@ -1226,7 +1226,7 @@ export class EdicionActaRecibidoComponent implements OnInit {
     this.firstForm.get('Formulario2')['controls'][0].get('Fecha_Factura').patchValue('');
     this.firstForm.get('Formulario2')['controls'][0].get('Fecha_Factura').setErrors(null);
   }
-  
+
   private validarTercero(): ValidatorFn {
     return (control: AbstractControl): ValidationErrors | null => {
       const valor = control.value;

--- a/src/app/pages/acta-recibido/registro-acta-recibido/registro-acta-recibido.component.html
+++ b/src/app/pages/acta-recibido/registro-acta-recibido/registro-acta-recibido.component.html
@@ -115,7 +115,7 @@
                               <div class="input-group">
                                 <input nbInput
                                   placeholder="{{'GLOBAL.Acta_Recibido.RegistroActa.FechaFiltro' | translate}}"
-                                  class="form-control" [nbDatepicker]="formpicker" formControlName="Fecha_Factura">
+                                  class="form-control" [nbDatepicker]="formpicker" formControlName="Fecha_Factura" (keyup.Backspace)="clear()">
                                 <nb-datepicker #formpicker [max]="TodaysDate" (dateChange)="usarLocalStorage()">
                                 </nb-datepicker>
                               </div>

--- a/src/app/pages/acta-recibido/registro-acta-recibido/registro-acta-recibido.component.html
+++ b/src/app/pages/acta-recibido/registro-acta-recibido/registro-acta-recibido.component.html
@@ -48,13 +48,13 @@
                     </mat-option>
                   </mat-autocomplete>
                   <p class="campo"
-                    *ngIf="firstForm.get('Formulario1.Contratista').errors && firstForm.get('Formulario1.Contratista').errors.required ? true : false">
+                    *ngIf="firstForm.get('Formulario1.Contratista').errors && firstForm.get('Formulario1.Contratista').errors.required">
                     {{'GLOBAL.placeholder' | translate}}</p>
                   <p class="campo"
-                    *ngIf="firstForm.get('Formulario1.Contratista').errors && firstForm.get('Formulario1.Contratista').errors.errorLongitudMinima ? true : false">
+                    *ngIf="firstForm.get('Formulario1.Contratista').errors && firstForm.get('Formulario1.Contratista').errors.errorLongitudMinima">
                     {{'GLOBAL.Errores.ErrorMinLength' | translate : {NUM : '4'} }}</p>
                   <p class="campo"
-                    *ngIf="firstForm.get('Formulario1.Contratista').errors && firstForm.get('Formulario1.Contratista').errors.terceroNoValido ? true : false">
+                    *ngIf="firstForm.get('Formulario1.Contratista').errors && firstForm.get('Formulario1.Contratista').errors.terceroNoValido">
                     {{'GLOBAL.Errores.ErrorTercero' | translate}}</p>
                 </div>
               </div>
@@ -96,10 +96,10 @@
                                 </mat-option>
                               </mat-autocomplete>
                               <p class="campo"
-                                *ngIf="soporte.get('Proveedor').errors && soporte.get('Proveedor').errors.errorLongitudMinima ? true : false">
+                                *ngIf="soporte.get('Proveedor').errors && soporte.get('Proveedor').errors.errorLongitudMinima">
                                 {{'GLOBAL.Errores.ErrorMinLength' | translate : {NUM : '4'} }}</p>
                               <p class="campo"
-                                *ngIf="soporte.get('Proveedor').errors && soporte.get('Proveedor').errors.terceroNoValido ? true : false">
+                                *ngIf="soporte.get('Proveedor').errors && soporte.get('Proveedor').errors.terceroNoValido">
                                 {{'GLOBAL.Errores.ErrorTercero' | translate}}</p>
                             </div>
                             <div class="form-group col-sm">

--- a/src/app/pages/acta-recibido/registro-acta-recibido/registro-acta-recibido.component.ts
+++ b/src/app/pages/acta-recibido/registro-acta-recibido/registro-acta-recibido.component.ts
@@ -571,7 +571,7 @@ export class RegistroActaRecibidoComponent implements OnInit {
 
   clear() {
     this.firstForm.get('Formulario2')['controls'][0].get('Fecha_Factura').patchValue('');
-    this.firstForm.get('Formulario2')['controls'][0].get('Fecha_Factura').updateValueAndValidity();
+    this.firstForm.get('Formulario2')['controls'][0].get('Fecha_Factura').setErrors(null);
   }
   private validarTercero(): ValidatorFn {
     return (control: AbstractControl): ValidationErrors | null => {

--- a/src/app/pages/acta-recibido/registro-acta-recibido/registro-acta-recibido.component.ts
+++ b/src/app/pages/acta-recibido/registro-acta-recibido/registro-acta-recibido.component.ts
@@ -571,7 +571,7 @@ export class RegistroActaRecibidoComponent implements OnInit {
 
   clear() {
     this.firstForm.get('Formulario2')['controls'][0].get('Fecha_Factura').patchValue('');
-    this.firstForm.get('Formulario2')['controls'][0].get('Fecha_Factura').setErrors(null);
+    this.firstForm.get('Formulario2')['controls'][0].get('Fecha_Factura').updateValueAndValidity();
   }
   private validarTercero(): ValidatorFn {
     return (control: AbstractControl): ValidationErrors | null => {

--- a/src/app/pages/acta-recibido/registro-acta-recibido/registro-acta-recibido.component.ts
+++ b/src/app/pages/acta-recibido/registro-acta-recibido/registro-acta-recibido.component.ts
@@ -569,6 +569,10 @@ export class RegistroActaRecibidoComponent implements OnInit {
     }
   }
 
+  clear() {
+    this.firstForm.get('Formulario2')['controls'][0].get('Fecha_Factura').patchValue('');
+    this.firstForm.get('Formulario2')['controls'][0].get('Fecha_Factura').setErrors(null);
+  }
   private validarTercero(): ValidatorFn {
     return (control: AbstractControl): ValidationErrors | null => {
       const valor = control.value;


### PR DESCRIPTION
El problema lo causa la directiva para limitar la fecha máxima. Se agrega funcionalidad para limpiar el campo de fecha y no muestre error